### PR TITLE
Migrate to poetry and add sample test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.coverage
+__pycache__/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,524 @@
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
+name = "black"
+version = "20.8b1"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = "*"
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+name = "click"
+version = "7.1.2"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "coverage"
+version = "5.5"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
+name = "importlib-metadata"
+version = "3.10.0"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+
+[[package]]
+name = "pastel"
+version = "0.2.1"
+description = "Bring colors to your terminal."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+name = "poethepoet"
+version = "0.10.0"
+description = "A task runner that works well with poetry."
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+pastel = ">=0.2.0,<0.3.0"
+tomlkit = ">=0.6.0,<1.0.0"
+
+[[package]]
+name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pytest"
+version = "6.2.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+coverage = ">=5.2.1"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "regex"
+version = "2021.4.4"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "soupsieve"
+version = "2.2.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomlkit"
+version = "0.7.0"
+description = "Style preserving TOML library"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "typed-ast"
+version = "1.4.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "zipp"
+version = "3.4.1"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "3377d9c949bd41b4828fcec72e9e61a103fe22f0b6653768f05057a3bf897310"
+
+[metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.9.3-py2-none-any.whl", hash = "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35"},
+    {file = "beautifulsoup4-4.9.3-py3-none-any.whl", hash = "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"},
+    {file = "beautifulsoup4-4.9.3.tar.gz", hash = "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25"},
+]
+black = [
+    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+coverage = [
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-3.10.0-py3-none-any.whl", hash = "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"},
+    {file = "importlib_metadata-3.10.0.tar.gz", hash = "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+]
+pastel = [
+    {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
+    {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+pathspec = [
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+poethepoet = [
+    {file = "poethepoet-0.10.0-py3-none-any.whl", hash = "sha256:6fb3021603d4421c6fcc40072bbcf150a6c52ef70ff4d3be089b8b04e015ef5a"},
+    {file = "poethepoet-0.10.0.tar.gz", hash = "sha256:70b97cb194b978dc464c70793e85e6f746cddf82b84a38bfb135946ad71ae19c"},
+]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-6.2.3-py3-none-any.whl", hash = "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"},
+    {file = "pytest-6.2.3.tar.gz", hash = "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
+]
+regex = [
+    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
+    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
+    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
+    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
+    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
+    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
+    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
+    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
+    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
+    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
+    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
+    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
+    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
+]
+soupsieve = [
+    {file = "soupsieve-2.2.1-py3-none-any.whl", hash = "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"},
+    {file = "soupsieve-2.2.1.tar.gz", hash = "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
+    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+zipp = [
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "world-manager"
+version = "0.0.1"
+description = ""
+authors = ["jegasus"]
+
+[tool.poetry.scripts]
+jwm = "world_manager.cli:cli"
+
+[tool.poe.tasks]
+test = "pytest --cov=world_manager -v"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+beautifulsoup4 = "^4.9.3"
+
+[tool.poetry.dev-dependencies]
+poethepoet = "^0.10.0"
+pytest = "^6.2.3"
+pytest-cov = "^2.11.1"
+black = "^20.8b1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -1,0 +1,17 @@
+from world_manager import world_manager
+
+
+def test_dict_walker():
+    sample_dict = {'part_1':[5,6,7],
+               'part_2':[3,6,{'a':999,
+                              'b':777,
+                              'c':123}]}
+    result = list(world_manager.dict_walker(sample_dict))
+    assert result == [['part_1', 0, 5],
+    ['part_1', 1, 6],
+    ['part_1', 2, 7],
+    ['part_2', 0, 3],
+    ['part_2', 1, 6],
+    ['part_2', 2, 'a', 999],
+    ['part_2', 2, 'b', 777],
+    ['part_2', 2, 'c', 123]]

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -2,16 +2,18 @@ from world_manager import world_manager
 
 
 def test_dict_walker():
-    sample_dict = {'part_1':[5,6,7],
-               'part_2':[3,6,{'a':999,
-                              'b':777,
-                              'c':123}]}
+    sample_dict = {
+        "part_1": [5, 6, 7],
+        "part_2": [3, 6, {"a": 999, "b": 777, "c": 123}],
+    }
     result = list(world_manager.dict_walker(sample_dict))
-    assert result == [['part_1', 0, 5],
-    ['part_1', 1, 6],
-    ['part_1', 2, 7],
-    ['part_2', 0, 3],
-    ['part_2', 1, 6],
-    ['part_2', 2, 'a', 999],
-    ['part_2', 2, 'b', 777],
-    ['part_2', 2, 'c', 123]]
+    assert result == [
+        ["part_1", 0, 5],
+        ["part_1", 1, 6],
+        ["part_1", 2, 7],
+        ["part_2", 0, 3],
+        ["part_2", 1, 6],
+        ["part_2", 2, "a", 999],
+        ["part_2", 2, "b", 777],
+        ["part_2", 2, "c", 123],
+    ]

--- a/world_manager/cli.py
+++ b/world_manager/cli.py
@@ -10,13 +10,7 @@ import argparse
 import os
 import sys
 
-# Path to the folder that contains the jegasus_world_manager.py file
-#world_ref_tool_location = r'D:\Dropbox\Foundry\dev_data_github\world-manager'
-world_manager_location = __file__
-sys.path.append(world_manager_location)
-
-# Importing the tool
-import jegasus_world_manager as jwm 
+from . import world_manager as jwm
 
 # Getting username for default folder path
 username = os.getlogin()
@@ -31,37 +25,41 @@ elif sys.platform.lower() == 'linux':
     default_core_data_folder = f'/home/{username}/foundryvtt/resources/app/public'
     default_ffmpeg_location  = '/usr/bin/ffmpeg'
 
-# Command used to supress multiple warnings about trying to parse regular 
-# strings as HTML chunks. 
+# Command used to supress multiple warnings about trying to parse regular
+# strings as HTML chunks.
 warnings.filterwarnings('ignore')
 
 # Setting up the argparse variables.
 # These commands/statements are needed to run the tool from the command line.
 parser = argparse.ArgumentParser(description="Jegasus' World Manager - Tool that can be used to compress FoundryVTT worlds.")
-parser.add_argument('-u','--user-data-folder', type=str, metavar='', 
+parser.add_argument('-u','--user-data-folder', type=str, metavar='',
                     help=f'Foundry User Data folder. Ex: "{default_user_data_folder}"',
                     default=default_user_data_folder)
-parser.add_argument('-w','--world-folder', type=str, metavar='', 
+parser.add_argument('-w','--world-folder', type=str, metavar='',
                     help=r'Foundry World folder. Ex: "worlds\kobold-cauldron", "worlds\porvenir"',
                     default="")
-parser.add_argument('-c','--core-data-folder', type=str, metavar='', 
+parser.add_argument('-c','--core-data-folder', type=str, metavar='',
                     help=f'Foundry Core folder. Ex: "{default_core_data_folder}"',
                     default=default_core_data_folder)
-parser.add_argument('-f','--ffmpeg-location', type=str, metavar='', 
+parser.add_argument('-f','--ffmpeg-location', type=str, metavar='',
                     help=f'Location of the FFMPEG application/executable. Ex: "{default_ffmpeg_location}"',
                     default=default_ffmpeg_location)
-parser.add_argument('-d','--delete-unreferenced-images', type=str, metavar='', 
-                    help=r'Flag that determines whether or not to delete unreferenced images. Should be "y" or "n".', 
+parser.add_argument('-d','--delete-unreferenced-images', type=str, metavar='',
+                    help=r'Flag that determines whether or not to delete unreferenced images. Should be "y" or "n".',
                     default='n')
 args = parser.parse_args()
 
-# Main function - this function is run automatically when this script is run.
-if __name__ == '__main__':
+
+def cli():
     # Running the tool to compress the world
     my_world_refs = jwm.one_liner_compress_world(
             user_data_folder=args.user_data_folder,
             world_folder=args.world_folder,
             core_data_folder=args.core_data_folder,
-            ffmpeg_location=args.ffmpeg_location, 
+            ffmpeg_location=args.ffmpeg_location,
             delete_unreferenced_images=args.delete_unreferenced_images)
 
+
+# Main function - this function is run automatically when this script is run.
+if __name__ == '__main__':
+    cli()

--- a/world_manager/world_manager.py
+++ b/world_manager/world_manager.py
@@ -1701,13 +1701,3 @@ def one_liner_compress_world(user_data_folder=None, world_folder=None,core_data_
     my_world_refs.empty_trash(delete_unreferenced_images_checked)
 
     return my_world_refs
-
-
-
-
-
-
-
-
-
-

--- a/world_manager/world_manager.py
+++ b/world_manager/world_manager.py
@@ -6,7 +6,7 @@ Created on Sat Mar 13 14:23:05 2021
 
 """
 
-import os 
+import os
 import json
 import re
 import pathlib
@@ -22,28 +22,28 @@ import hashlib
 
 from bs4 import BeautifulSoup
 
-# Command used to supress multiple warnings about trying to parse regular 
-# strings as HTML chunks. 
+# Command used to supress multiple warnings about trying to parse regular
+# strings as HTML chunks.
 warnings.filterwarnings('ignore')
 
 def dict_walker(in_dict, pre=None):
     '''
     Function that walks through an indefinitely complex dictionary (can contain
-    lists, tuples or other dictionaries), and iterates through all of the 
-    dictionary's "leaves". This works as an iterator that returns a big list 
-    that contains the full "address" of a leaf. 
-    
+    lists, tuples or other dictionaries), and iterates through all of the
+    dictionary's "leaves". This works as an iterator that returns a big list
+    that contains the full "address" of a leaf.
+
     Modified from https://stackoverflow.com/a/12507546/8667016
-    
+
     INPUTS:
     -------
     in_dict (DICT) : A dictionary of arbitrary depth/complexity.
-        
+
     RETURNS:
     --------
-    iterated_output (LIST) : A list that contains the full address of the leaf 
+    iterated_output (LIST) : A list that contains the full address of the leaf
         in the dictionary.
-        
+
     EXAMPLE:
     --------
     # Input:
@@ -51,10 +51,10 @@ def dict_walker(in_dict, pre=None):
                'part_2':[3,6,{'a':999,
                               'b':777,
                               'c':123}]}
-    
+
     for this_full_address in dict_walker(in_dict=my_dict):
         print(this_full_address)
-    
+
     # Output:
     # ['part_1', 0, 5]
     # ['part_1', 1, 6]
@@ -65,7 +65,7 @@ def dict_walker(in_dict, pre=None):
     # ['part_2', 2, 'b', 777]
     # ['part_2', 2, 'c', 123]
     '''
-    
+
     pre = pre[:] if pre else []
     if isinstance(in_dict, dict):
         for key, value in in_dict.items():
@@ -84,20 +84,20 @@ def dict_walker(in_dict, pre=None):
 
 def get_nested_dict_recursive(in_dict, dict_address):
     '''
-    Function that allows you to access a specific "address" inside an 
+    Function that allows you to access a specific "address" inside an
     arbitrarily-complex dictionary.
-    
+
     INPUTS:
     -------
     in_dict (DICT) : Dictionary to be read.
     dict_address (LIST) : Address of the object being requested.
-    
+
     RETURNS:
     --------
-    output (any) : The output of this function is the actual item at the 
-        "address" inside the input dictionary. 
+    output (any) : The output of this function is the actual item at the
+        "address" inside the input dictionary.
 
-        
+
     EXAMPLE:
     --------
     # Input:
@@ -105,13 +105,13 @@ def get_nested_dict_recursive(in_dict, dict_address):
                'part_2':[3,6,{'a':999,
                               'b':777,
                               'c':123}]}
-    
+
     address_1 = ['part_1', 2]
     address_2 = ['part_2', 2]
-    
+
     print(get_nested_dict_recursive(in_dict=my_dict, dict_address=address_1))
     print(get_nested_dict_recursive(in_dict=my_dict, dict_address=address_2))
-    
+
     # Output:
     # 7
     # {'a': 999, 'b': 777, 'c': 123}
@@ -123,19 +123,19 @@ def get_nested_dict_recursive(in_dict, dict_address):
 
 def edit_nested_dict_recursive(in_dict, dict_address, new_value):
     '''
-    Function that allows you to edit a specific "address" inside an 
+    Function that allows you to edit a specific "address" inside an
     arbitrarily-complex dictionary and assign a new value/object to it.
-    
+
     INPUTS:
     -------
     in_dict (DICT) : Dictionary to be read.
     dict_address (LIST) : Address of the object that will receive `new_value`.
     new_value (any) : New value to be stored in the input dictionary's "address".
-    
+
     RETURNS:
     --------
     None
-        
+
     EXAMPLE:
     --------
     # Input:
@@ -143,18 +143,18 @@ def edit_nested_dict_recursive(in_dict, dict_address, new_value):
                'part_2':[3,6,{'a':999,
                               'b':777,
                               'c':123}]}
-    
+
     my_address = ['part_1', 2]
     my_new_value = 'DOG'
-    
+
     edit_nested_dict_recursive(my_dict, my_address, my_new_value)
-    
+
     print(my_dict)
-    
+
     # Output:
-    # {'part_1': [5, 6, 'DOG'], 
-    #  'part_2': [3, 6, {'a': 999, 
-    #                    'b': 777, 
+    # {'part_1': [5, 6, 'DOG'],
+    #  'part_2': [3, 6, {'a': 999,
+    #                    'b': 777,
     #                    'c': 123}]}
     '''
     if len(dict_address) == 1:
@@ -164,227 +164,227 @@ def edit_nested_dict_recursive(in_dict, dict_address, new_value):
 
 class img_ref:
     '''
-    Class that encapsules one single image reference inside the Foundry world. 
+    Class that encapsules one single image reference inside the Foundry world.
     This class contains several helpful methods and attributes that make it easy
     to understand the image reference.
-    Mainly, the `img_ref` object contains information about where this image 
-    reference is located in the world. 
+    Mainly, the `img_ref` object contains information about where this image
+    reference is located in the world.
     For example, if there is a journal entry that makes a reference to
-    "worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp", an `img_ref` 
-    instance can be created to indicate exactly where in the world folder this 
-    reference can be found: inside the 4th line of the "worlds/myworld/data/journal.db" 
+    "worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp", an `img_ref`
+    instance can be created to indicate exactly where in the world folder this
+    reference can be found: inside the 4th line of the "worlds/myworld/data/journal.db"
     file, at the following "address": ['img', 'worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp'].
-    Among many other things, this object also includes an attribute that indicates 
-    the image's filetype/extension (JPG, PNG, WEBP), and an attribute that helps 
-    determine whether the image was actually encoded using its filename's 
-    extension's protocols. 
-    
+    Among many other things, this object also includes an attribute that indicates
+    the image's filetype/extension (JPG, PNG, WEBP), and an attribute that helps
+    determine whether the image was actually encoded using its filename's
+    extension's protocols.
+
     Main attributes:
         Attributes that never change:
         -----------------------------
         self.world_folder (STR) : Folder path of the current world
         self.core_data_folder (STR) : Folder path of the Foundry installation
-        self.ref_file_path (STR) : Indicates the filepath to the file that contains 
-            this image reference. For example, if an image reference is made 
-            inside the world's "journal.db" file, the `ref_file_path` would be 
+        self.ref_file_path (STR) : Indicates the filepath to the file that contains
+            this image reference. For example, if an image reference is made
+            inside the world's "journal.db" file, the `ref_file_path` would be
             something like "worlds/myworld/data/journal.db"
-        self.ref_file_type (STR) : Type of file in which this reference was found. 
+        self.ref_file_type (STR) : Type of file in which this reference was found.
             Can be either "json" or "db".
-        self.ref_file_line (INT or None): For '.db' reference files, there are multiple 
-            JSON-like dictionaries per row. The `ref_file_line` argument indicates 
-            which line in the ".db" file this particular `img_ref` can be found. 
-            For example, if the reference to the image is on the 5th line of the 
-            "journal.db" file, then `ref_file_line` will equal 4. In cases where 
-            the reference was found in a ".json" file, this attribute is instead 
+        self.ref_file_line (INT or None): For '.db' reference files, there are multiple
+            JSON-like dictionaries per row. The `ref_file_line` argument indicates
+            which line in the ".db" file this particular `img_ref` can be found.
+            For example, if the reference to the image is on the 5th line of the
+            "journal.db" file, then `ref_file_line` will equal 4. In cases where
+            the reference was found in a ".json" file, this attribute is instead
             set to None.
             NOTE: As with everything else in Python, this line number is zero-indexed.
-        self.json_address (LIST) : Full "address" of the reference inside the "db" 
+        self.json_address (LIST) : Full "address" of the reference inside the "db"
             or "json" file.
         self.world_references_owner_obj (world_refs) : Object that "owns"
             this reference. This is a collection of `img_ref`s.
-        self.img_ref_content_is_html (BOOL) : Indicates whether this reference is 
+        self.img_ref_content_is_html (BOOL) : Indicates whether this reference is
             just a simple STRING or if it's an HTML chunk.
-        
+
         Attributes that are mutable:
         ----------------------------
-        self.ref_img_in_world_folder (BOOL) : Indicates whether or not this 
-            reference tries to point to an image file on disk that is inside 
+        self.ref_img_in_world_folder (BOOL) : Indicates whether or not this
+            reference tries to point to an image file on disk that is inside
             the world folder.
-        self.img_path_on_disk (STR) : File path on disk to which this reference 
+        self.img_path_on_disk (STR) : File path on disk to which this reference
             points. The difference between this and the `ref_file_path` attribute
             is that if the image being referenced is inside the Foundry Core folder,
             the `img_path_on_disk` attribute will have the full absolute path to
             the image on disk. The `ref_file_path` attibute, however, will only have
             the "stem" of the path (i.e., the image path relative to the Foundry
             Core folder).
-            Furthermore, in cases where the image does not exist on disk, the 
+            Furthermore, in cases where the image does not exist on disk, the
             `the img_path_on_disk` attribute is set to an error value.
         self.img_exists (BOOL) : Indicates whether or not this file actually exists
             on disk
         self.img_encoding (STR) : Type of encoding used for the image. Expected
             values can be "png", "jpeg" or "webp".
-        self.correct_extension (BOOL) : Indicates whether or not the encoding 
-            actually matches the file extension. For example, if a file is named 
+        self.correct_extension (BOOL) : Indicates whether or not the encoding
+            actually matches the file extension. For example, if a file is named
             "my_img.jpeg", but it was encoded using "png", the `correct_extension`
             attribute will be False.
         self.img_hash (STR) : Hash of the image file on disk. Used for de-duplication.
         self.is_webp (BOOL) : Indicates whether or not the file extension is ".webp"
-        self.webp_img_path_for_ref (STR) : File path for the ".webp" version of 
+        self.webp_img_path_for_ref (STR) : File path for the ".webp" version of
             this image (regardless of whether or not the ".webp" version exists).
         self.webp_copy_exists (BOOL) : Indicates whether or not the ".webp" version
             of this image exists on disk
-        self.img_ref_external_web_link (BOOL) : Indicates whether or not this 
+        self.img_ref_external_web_link (BOOL) : Indicates whether or not this
             image reference is actually a hyperlink to an external file on
             the web.
         self.trash_folder_location (STR) : Indicates the folder location of where
             this file needs to go if it needs to be moved to the trash
 
     '''
-    
-    def __init__(self, ref_file_type=None, ref_file_path=None, ref_file_line=None, 
+
+    def __init__(self, ref_file_type=None, ref_file_path=None, ref_file_line=None,
                  full_json_address=None, img_path_for_ref=None,
                  world_refs_obj=None):
         '''
         Function used to instantiate new objects from the `img_ref` class.
-        
+
         INPUTS:
         -------
-        ref_file_type (STR) Indicates the file type of the location where this 
-            image reference is stored. Can only take two values: 'json' or 'db'. 
-        ref_file_path (STR) : Indicates the filepath to the file that contains 
-            this image reference. For example, if an image reference is made 
-            inside the world's "journal.db" file, the `ref_file_path` would be 
+        ref_file_type (STR) Indicates the file type of the location where this
+            image reference is stored. Can only take two values: 'json' or 'db'.
+        ref_file_path (STR) : Indicates the filepath to the file that contains
+            this image reference. For example, if an image reference is made
+            inside the world's "journal.db" file, the `ref_file_path` would be
             something like "worlds/myworld/data/journal.db"
-        ref_file_line (INT or None): For '.db' reference files, there are multiple 
-            JSON-like dictionaries per row. The `ref_file_line` argument indicates 
-            which line in the ".db" file this particular `img_ref` can be found. 
-            For example, if the reference to the image is on the 5th line of the 
-            "journal.db" file, then `ref_file_line` will equal 4. In cases where 
-            the reference was found in a ".json" file, this attribute is instead 
+        ref_file_line (INT or None): For '.db' reference files, there are multiple
+            JSON-like dictionaries per row. The `ref_file_line` argument indicates
+            which line in the ".db" file this particular `img_ref` can be found.
+            For example, if the reference to the image is on the 5th line of the
+            "journal.db" file, then `ref_file_line` will equal 4. In cases where
+            the reference was found in a ".json" file, this attribute is instead
             set to None.
             NOTE: As with everything else in Python, this line number is zero-indexed.
-        full_json_address (LIST) : Full "address" of an image's reference inside 
-            the complex JSON dictionary. 
-        img_path_for_ref (STR) : Actual disk location/filepath of the image being 
+        full_json_address (LIST) : Full "address" of an image's reference inside
+            the complex JSON dictionary.
+        img_path_for_ref (STR) : Actual disk location/filepath of the image being
             referenced. Ex: "worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp"
-        world_refs_obj (OBJECT) : This is an instance of the `world_refs` object 
+        world_refs_obj (OBJECT) : This is an instance of the `world_refs` object
             (defined below). The `world_refs_obj` attribute points to the `world_refs`
-            object to which this `img_ref` belongs, and inside of which all other 
+            object to which this `img_ref` belongs, and inside of which all other
             image references can be found.
         ref_id (STR) : Unique string that can be used to identify each individual
             `img_ref` object
-        
+
         RETURNS:
         --------
         img_ref (OBJECT) : The newly created `img_ref` object itself.
-            
+
         EXAMPLE:
         --------
         # Input:
-        my_ref = img_ref(ref_file_type='db', 
-                         ref_file_path='worlds/myworld/data/journal.db', 
-                         ref_file_line=4, 
-                         full_json_address=['img', 'worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp'], 
+        my_ref = img_ref(ref_file_type='db',
+                         ref_file_path='worlds/myworld/data/journal.db',
+                         ref_file_line=4,
+                         full_json_address=['img', 'worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp'],
                          img_path_for_ref='worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp',
                          world_refs_obj=my_world_refs)
-        
+
         # Output:
         # None
         '''
-        
+
         # Setting attributes that will never be updated
-        self.world_folder = world_refs_obj.world_folder 
-        self.core_data_folder = world_refs_obj.core_data_folder 
+        self.world_folder = world_refs_obj.world_folder
+        self.core_data_folder = world_refs_obj.core_data_folder
         self.ref_file_path = ref_file_path
         self.ref_file_type = ref_file_type
         self.ref_file_line = ref_file_line
-        self.json_address  = full_json_address[:-1] 
+        self.json_address  = full_json_address[:-1]
         self.world_references_owner_obj = world_refs_obj
-        
+
         # Setting the unique ID for this `ref_img`
         string_to_hash = (self.world_folder + self.core_data_folder + self.ref_file_path +
                           self.ref_file_type + str(self.ref_file_line) + str(self.json_address)
                           + 'img_ref')
-        
+
         self.ref_id = hashlib.sha256(string_to_hash.encode()).hexdigest()
-        
+
         # Looks into the actual content of the reference. Sometimes it is just
-        # a string with the filepath to the image. Other times it is a chunk of 
-        # HTML that links to an embedded image. In any case, this content needs 
+        # a string with the filepath to the image. Other times it is a chunk of
+        # HTML that links to an embedded image. In any case, this content needs
         # to be investigated to generate a bunch of the `img_ref`'s attributes.
         img_ref_content = full_json_address[-1]
-        
+
         # Checking if the content of the reference is an HTML chunk.
         self.img_ref_content_is_html = True if BeautifulSoup(img_ref_content, 'html.parser').find() else False
-        
+
         # Setting the attributes that might be edited later.
         self.set_editable_attributes(img_path_for_ref)
-    
+
     def get_img_ref_content(self):
         '''
         Retrieves this `img_ref`'s content from the main world reference object
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
-        img_ref_content (STR) : The actual content of the reference. Sometimes 
-            it is just a string with the filepath to the image. Other times it 
+        img_ref_content (STR) : The actual content of the reference. Sometimes
+            it is just a string with the filepath to the image. Other times it
             is a chunk of HTML that links to an embedded image.
-        
+
         EXAMPLE:
         --------
         # Input:
         print(my_ref.get_img_ref_content())
-        
+
         # Output:
         # 'worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp'
         '''
-        
-        
-        
+
+
+
         if self.ref_file_type == "db":
             this_ref_file_dict = self.world_references_owner_obj.db_files[self.ref_file_path][self.ref_file_line]
         elif self.ref_file_type == "json":
             this_ref_file_dict = self.world_references_owner_obj.json_files[self.ref_file_path]
-        
+
         this_address = self.json_address
-        
+
         img_ref_content = get_nested_dict_recursive(this_ref_file_dict,this_address)
-        
+
         return img_ref_content
-        
-        
+
+
     def set_editable_attributes(self, img_path_for_ref=None):
         '''
-        This is where several of the `img_ref`'s helper attributes get initially 
-        set, such as the attribute that determines whether the image was actually 
+        This is where several of the `img_ref`'s helper attributes get initially
+        set, such as the attribute that determines whether the image was actually
         encoded using its filename's extension's protocols.
-        
+
         INPUTS:
         -------
-        img_path_for_ref (STR) : Actual disk location/filepath of the image 
+        img_path_for_ref (STR) : Actual disk location/filepath of the image
             being referenced. Ex: "worlds/porvenir/handouts/ScytheOfTheHeadlessHorseman.webp"
-        
+
         RETURNS:
         --------
         None
-            
+
         EXAMPLE:
         --------
         # Input:
         my_img_path_for_ref = my_ref.full_json_address[:-1]
-        
+
         my_img_ref.set_editable_attributes(my_img_path_for_ref)
-        
+
         '''
-        
+
         self.img_path_for_ref = img_path_for_ref
-        
+
         self.ref_img_in_world_folder = True if img_path_for_ref[:len(self.world_folder)] == self.world_folder else False
-        
+
         if os.path.isfile(self.img_path_for_ref):
             self.img_path_on_disk = self.img_path_for_ref
             self.img_exists = True
@@ -395,22 +395,22 @@ class img_ref:
             self.img_path_on_disk = 'ERROR!!! IMG REFERENCE NOT ON DISK!!!'
             self.img_exists = False
             self.img_encoding = None
-        
+
         if self.img_exists:
             img_encoding_imghdr = imghdr.what(self.img_path_on_disk)
-            
+
             img_encoding_mime_temp = mimetypes.guess_type(self.img_path_on_disk)[0]
             img_encoding_mime      = img_encoding_mime_temp.split('/')[1].lower() if img_encoding_mime_temp != None else None
-            
+
             if img_encoding_imghdr:
                 self.img_encoding = img_encoding_imghdr
             elif img_encoding_mime:
                 self.img_encoding = img_encoding_mime
             else:
                 self.img_encoding = None
-            
+
         if self.img_encoding:
-            
+
             self.img_encoding = self.img_encoding.lower()
             if self.img_encoding == 'jpeg':
                 if pathlib.Path(self.img_path_on_disk).suffix[1:].lower() == 'jpeg' or pathlib.Path(self.img_path_on_disk).suffix[1:].lower() == 'jpg':
@@ -426,7 +426,7 @@ class img_ref:
         self.webp_img_path_for_ref =  (os.path.join(pathlib.Path(self.img_path_for_ref).parent,pathlib.Path(self.img_path_for_ref).stem) + '.webp').replace('\\','/')
         self.webp_copy_exists = None if self.is_webp else os.path.isfile(self.webp_img_path_for_ref)
         self.img_ref_external_web_link = True if (self.img_path_for_ref.find('http:') >= 0 or self.img_path_for_ref.find('https:') >= 0) else False
-        
+
         if os.path.isfile(self.img_path_for_ref) and self.ref_img_in_world_folder:
             trash_folder_location = re.split('\\\\|/',self.img_path_on_disk)
             trash_folder_location.insert(2,'_trash')
@@ -434,7 +434,7 @@ class img_ref:
             self.trash_folder_location = trash_folder_location
         else:
             self.trash_folder_location = 'ERROR!!! IMG REFERENCE NOT ON DISK!!!'
-        
+
     def print_ref(self):
         '''
         Prints the `img_ref`'s main data to the screen.
@@ -448,74 +448,74 @@ class img_ref:
             -The full JSON address of the reference
             -The first 255 characters of the content of the reference.
         Note: the multiple parts are separated by a "pipe" ( the | character).
-                
-        
+
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-            
+
         EXAMPLE:
         --------
         # Input:
         my_ref.printref()
-        
+
         # Output:
-        # worlds/porvenir/art/porvenir-banner.webp | webp | worlds/porvenir/world.json -1 | ['description'] | <img title="The Secret of the Porvenir" src="worlds/porvenir/art/porvenir-banner.webp" />The Secret of the Porvenir is a spooktacular game-ready adventure for 5th Edition.<blockquote>The Porvenir - missing for weeks, feared lost - has mysteriously returne | 
+        # worlds/porvenir/art/porvenir-banner.webp | webp | worlds/porvenir/world.json -1 | ['description'] | <img title="The Secret of the Porvenir" src="worlds/porvenir/art/porvenir-banner.webp" />The Secret of the Porvenir is a spooktacular game-ready adventure for 5th Edition.<blockquote>The Porvenir - missing for weeks, feared lost - has mysteriously returne |
         '''
-        
+
         print_str = f'{self.img_path_for_ref} | '
         print_str = print_str + f'{self.img_encoding if self.img_encoding else "404 IMG NOT FOUND"} | '
         print_str = print_str + f'{self.ref_file_path} {self.ref_file_line if self.ref_file_type == "db" else "-1"} | '
         print_str = print_str + f'{self.json_address} | '
         print_str = print_str + f'{self.get_img_ref_content()[:255]} | '
         print(print_str)
-        
+
     def create_webp_copy(self):
         '''
-        Creates a compressed ".webp" copy of the image being referenced in the 
-        `img_ref` object. 
-        
+        Creates a compressed ".webp" copy of the image being referenced in the
+        `img_ref` object.
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         subprocess_output.returncode (INT) : Indicates whether or not the conversion
-            process terminated successfully. This value takes 0 if the conversion 
+            process terminated successfully. This value takes 0 if the conversion
             was successful. All other values indicate some sort of problem.
-            
+
         EXAMPLE:
         --------
         # Input:
         my_ref.create_webp_copy()
-        
+
         # Output:
         # None
         '''
         # The actual string that needs to be sent to the command line
         cmd_call_str = f'"{self.world_references_owner_obj.ffmpeg_location}" -y -i "{self.img_path_for_ref}" -c:v libwebp "{self.webp_img_path_for_ref}" -hide_banner -loglevel error'
-        
+
         # Running terminal command (https://stackoverflow.com/a/48857230/8667016)
         # The exit code here is 0 if the conversion succeeded. If it is anything
         # else, it means the conversion process failed.
         subprocess_output = subprocess.run(shlex.split(cmd_call_str))
-        
-        # Some files have the incorrect extention. For example, an image that 
+
+        # Some files have the incorrect extention. For example, an image that
         # was compressed using a JPEG protocol but had a PNG extension.
-        # To fix this, I need to check if FFMPEG's conversion succeeds or not. 
-        # When FFMPEG fails to convert, I need to try converting it using another 
+        # To fix this, I need to check if FFMPEG's conversion succeeds or not.
+        # When FFMPEG fails to convert, I need to try converting it using another
         # protocol (jpeg or png - the opposite of what was used in the first call)
-        # Note: The section below is commented out because I created a method 
-        # that tries to fix the jpeg/png file extension beforehand. Therefore, 
+        # Note: The section below is commented out because I created a method
+        # that tries to fix the jpeg/png file extension beforehand. Therefore,
         # this part of the code should be unnecessary.
         '''
         if subprocess_output.returncode != 0:
-            # Check the extension/suffix of the current file and generates a 
+            # Check the extension/suffix of the current file and generates a
             # temporary copy of the file with the "opposite" extension
             original_suffix = str(pathlib.Path(self.img_path_for_ref).suffix)
             if original_suffix == '.jpg' or original_suffix == '.jpeg':
@@ -524,46 +524,46 @@ class img_ref:
                 new_suffix = '.jpg'
             temp_img_path = os.path.join(pathlib.Path(self.img_path_for_ref).parent,pathlib.Path(self.img_path_for_ref).stem).replace('\\','/') + new_suffix
             shutil.copyfile(self.img_path_for_ref, temp_img_path)
-            
+
             # Run the FFMPEG call using the new filename
             new_cmd_call_str = f'"{self.ffmpeg_location}" -y -i "{temp_img_path}" -c:v libwebp "{self.webp_img_path_for_ref}"'
             new_subprocess_output = subprocess.run(shlex.split(new_cmd_call_str))
-            
+
             # Delete the temporary file created
             os.remove(temp_img_path)
-            
+
             # Checking if the new conversion process was successful
             if new_subprocess_output.returncode == 0:
                 subprocess_output = new_subprocess_output
         '''
         return subprocess_output.returncode
-        
-    
+
+
     def push_updated_content_to_world(self, updated_content):
         ''''
-        Pushes content from the `updated_content` string back into the 
-        `world_refs` object. 
-        
+        Pushes content from the `updated_content` string back into the
+        `world_refs` object.
+
         INPUTS:
         -------
-        updated_content (STR) : Content that will be pushed back into the 
-            `world_refs` object. 
-        
+        updated_content (STR) : Content that will be pushed back into the
+            `world_refs` object.
+
         RETURNS:
         --------
         subprocess_output.returncode (INT) : Indicates whether or not the conversion
-            process terminated successfully. This value takes 0 if the conversion 
+            process terminated successfully. This value takes 0 if the conversion
             was successful. All other values indicate some sort of problem.
-            
+
         EXAMPLE:
         --------
         # Input:
         my_ref.push_updated_content_to_world(updated_content)
-        
+
         # Output:
         # None
         '''
-        
+
         if self.ref_file_type == 'json':
             edit_nested_dict_recursive(self.world_references_owner_obj.json_files[self.ref_file_path],
                                        self.json_address,
@@ -577,45 +577,45 @@ class img_ref:
 
 class world_refs:
     '''
-    Container object that represents the Foundry World. This object contains 
-    several helper attributes and methods, such as a function that searches the 
-    world folder for all the image files, and an attribute that is a list of 
+    Container object that represents the Foundry World. This object contains
+    several helper attributes and methods, such as a function that searches the
+    world folder for all the image files, and an attribute that is a list of
     all the `img_ref`s inside the world.
-    
+
     Main attributes:
-        self.user_data_folder (STR) : String that describes the absolute path for 
-            the user data folder on disk. On Windows installations, this attribute 
+        self.user_data_folder (STR) : String that describes the absolute path for
+            the user data folder on disk. On Windows installations, this attribute
             should typically look something like this: "C:/Users/jegasus/AppData/Local/FoundryVTT/Data"
-        self.world_folder (STR) : String that describes the relative path to the 
-            world folder to be scanned by the world reference tool. This path needs 
+        self.world_folder (STR) : String that describes the relative path to the
+            world folder to be scanned by the world reference tool. This path needs
             to be relative to the user data folder (i.e., the combination of the
-            `user_data_folder` attribute and the `world_folder` represent the 
-            absolute path of the World folder to be scanned. This attribute should 
+            `user_data_folder` attribute and the `world_folder` represent the
+            absolute path of the World folder to be scanned. This attribute should
             typically look like this: "worlds/porvenir", or "worlds/kobold-cauldron".
-        self.core_data_folder (STR) : String that describes the absolute path to the 
-            Foundry Core Data folder. This attribute should typically look like 
+        self.core_data_folder (STR) : String that describes the absolute path to the
+            Foundry Core Data folder. This attribute should typically look like
             this: "C:/Program Files/FoundryVTT/resources/app/public"
-        self.ffmpeg_location (STR) : String that describes the absolute path to 
+        self.ffmpeg_location (STR) : String that describes the absolute path to
             the ffmpeg executable. This attribute should typically look like this:
             "C:/Program Files (x86)/Audacity/libraries/ffmpeg.exe".
-        self.trash_folder (STR): String that describes the relative path to the 
+        self.trash_folder (STR): String that describes the relative path to the
             trash folder for this world. This path is relative to the path in the
-            `user_data_folder` attribute. This attribute should typically look 
+            `user_data_folder` attribute. This attribute should typically look
             like this: "worlds/porvenir/_trash", or "worlds/kobold-cauldron_trash".
-        self.trash_queue (SET) : Set of filenames that need to be moved to the 
+        self.trash_queue (SET) : Set of filenames that need to be moved to the
             trash folder.
-        self.all_img_refs (LIST) : List of all the `img_ref` objects found in 
+        self.all_img_refs (LIST) : List of all the `img_ref` objects found in
             the world's JSON and DB files.
-        self.all_img_refs_by_id (DICT) : Dictionary of all `img_ref` objects 
+        self.all_img_refs_by_id (DICT) : Dictionary of all `img_ref` objects
             indexed by `ref_id`
-        self.json_files (DICT) : Dictionary that holds the contents of all the 
+        self.json_files (DICT) : Dictionary that holds the contents of all the
             JSON files inside the World folder. The structure of this dictionary
-            is as follows: 
+            is as follows:
                 {'worlds/porvenir/world.json' : {json_dict_content},
                  'worlds/porvenir/descr.json' : {json_dict_content}}
-        self.db_files (DICT) : Dictionary that holds the contents of all the 
+        self.db_files (DICT) : Dictionary that holds the contents of all the
             DB files inside the World folder. The structure of this dictionary
-            is as follows: 
+            is as follows:
                 {'worlds/porvenir/data/actors.db   : [{json_dict_content},
                                                       {json_dict_content},
                                                       {json_dict_content}],
@@ -625,36 +625,36 @@ class world_refs:
                  'worlds/porvenir/data/items.db'   : [{json_dict_content},
                                                       {json_dict_content},
                                                       {json_dict_content}] }
-        
+
     '''
-    
+
     def __init__(self,user_data_folder,world_folder,core_data_folder,ffmpeg_location):
         '''
         Function used to instantiate new objects from the `world_refs` class.
-        
+
         INPUTS:
         -------
-        user_data_folder (STR) : String that describes the absolute path for 
-            the user data folder on disk. On Windows installations, this attribute 
+        user_data_folder (STR) : String that describes the absolute path for
+            the user data folder on disk. On Windows installations, this attribute
             should typically look something like this: "C:/Users/jegasus/AppData/Local/FoundryVTT/Data"
-        world_folder (STR) : String that describes the relative path to the 
-            world folder to be scanned by the world reference tool. This path needs 
+        world_folder (STR) : String that describes the relative path to the
+            world folder to be scanned by the world reference tool. This path needs
             to be relative to the user data folder (i.e., the combination of the
-            `user_data_folder` attribute and the `world_folder` represent the 
-            absolute path of the World folder to be scanned. This attribute should 
+            `user_data_folder` attribute and the `world_folder` represent the
+            absolute path of the World folder to be scanned. This attribute should
             typically look like this: "worlds/porvenir", or "worlds/kobold-cauldron".
-        core_data_folder (STR) : String that describes the absolute path to the 
-            Foundry Core Data folder. This attribute should typically look like 
+        core_data_folder (STR) : String that describes the absolute path to the
+            Foundry Core Data folder. This attribute should typically look like
             this: "C:/Program Files/FoundryVTT/resources/app/public"
-        ffmpeg_location (STR) : String that describes the absolute path to 
+        ffmpeg_location (STR) : String that describes the absolute path to
             the ffmpeg executable. This attribute should typically look like this:
             "C:/Program Files (x86)/Audacity/libraries/ffmpeg.exe".
 
-        
+
         RETURNS:
         --------
         world_refs (OBJECT) : The newly created `world_refs` object itself.
-            
+
         EXAMPLE:
         --------
         # Input:
@@ -663,15 +663,15 @@ class world_refs:
                 world_folder='worlds/porvenir',
                 core_data_folder='C:/Program Files/FoundryVTT/resources/app/public',
                 ffmpeg_location='C:/Program Files (x86)/Audacity/libraries/ffmpeg.exe')
-        
+
         # Output:
         # None
         '''
-        
+
         # Checking inputs
         checked_inputs = input_checker(user_data_folder,world_folder,
                                        core_data_folder,ffmpeg_location,'n')
-        
+
         user_data_folder = checked_inputs['user_data_folder']
         world_folder = checked_inputs['world_folder']
         core_data_folder = checked_inputs['core_data_folder']
@@ -682,37 +682,37 @@ class world_refs:
         self.world_folder     = world_folder.replace('\\','/')
         self.core_data_folder = core_data_folder.replace('\\','/')
         self.ffmpeg_location  = ffmpeg_location.replace('\\','/')
-        
+
         # Reading in the DB and JSON files inside the world
         self.load_db_and_json_files()
-        
+
         # Making the trash folder. This is where all the images to be deleted
         # will go before they are actually deleted.
         trash_folder = str(os.path.join(world_folder,'_trash'))
         os.makedirs(trash_folder, exist_ok=True)
         self.trash_folder = trash_folder
-        
+
         # Set of images that need to be moved to the trash
         self.trash_queue = set()
-        
+
         # Finds all the `img_ref` objects inthe world
         self.find_all_img_references_in_world()
-    
+
     def load_db_and_json_files(self):
         '''
-        Function that scans the world folder and loads in the contents of the 
+        Function that scans the world folder and loads in the contents of the
         DB and JSON files. This function defines two important attributes from the
         `world_refs` object: self.json_files and self.db_files.
-        
+
         Attributes set by this function:
-            self.json_files (DICT) : Dictionary that holds the contents of all the 
+            self.json_files (DICT) : Dictionary that holds the contents of all the
                 JSON files inside the World folder. The structure of this dictionary
-                is as follows: 
+                is as follows:
                     {'worlds/porvenir/world.json' : {json_dict_content},
                      'worlds/porvenir/descr.json' : {json_dict_content}}
-            self.db_files (DICT) : Dictionary that holds the contents of all the 
+            self.db_files (DICT) : Dictionary that holds the contents of all the
                 DB files inside the World folder. The structure of this dictionary
-                is as follows: 
+                is as follows:
                     {'worlds/porvenir/data/actors.db   : [{json_dict_content},
                                                           {json_dict_content},
                                                           {json_dict_content}],
@@ -722,151 +722,151 @@ class world_refs:
                      'worlds/porvenir/data/items.db'   : [{json_dict_content},
                                                           {json_dict_content},
                                                           {json_dict_content}] }
-                     
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         world_folder = self.world_folder
-        
+
         list_of_db_files   = [str(this_path).replace('\\','/') for this_path in pathlib.Path(world_folder).rglob('*.db')]
         list_of_json_files = [str(this_path).replace('\\','/') for this_path in pathlib.Path(world_folder).rglob('*.json')]
-        
-        
+
+
         self.db_files = {}
         for this_db_file  in list_of_db_files:
-            
+
             # Need to avoid the `settings.db` file
             if this_db_file != str(pathlib.Path(os.path.join(world_folder,'data/settings.db'))).replace('\\','/'):
                 pass
                 this_db_file_lines = []
                 # Reading the DB file
                 with open(this_db_file,'r',encoding="utf-8") as fp:
-            
+
                     # Initializing process to scan all lines in DB file
                     line_count = 0
                     line = fp.readline()
-                    
+
                     # Scanning all lines in DB file
                     while line:
-                        
+
                         # Transforming JSON-like string into a python dict
                         #line_dict = json.loads(line)
                         this_db_file_lines.append(json.loads(line))
-                        
+
                         # Preparing for next row
                         line_count += 1
                         line = fp.readline()
-                
+
                 # Adding this DB file's list of dictionaries into the main object
                 self.db_files[this_db_file] = this_db_file_lines
-        
-        
+
+
         self.json_files = {}
         for this_json_file in list_of_json_files:
             with open(this_json_file,'r',encoding="utf-8") as fp:
                 self.json_files[this_json_file] = json.load(fp)
-    
-    
+
+
     def find_all_img_references_in_world(self, return_result=False):
         '''
-        Scans the DB and JSON files inside the world and creates `img_ref` 
+        Scans the DB and JSON files inside the world and creates `img_ref`
         objects for each and every reference to image files. All of the `img_ref`
-        objects that are created in this process are appended to a list. This 
+        objects that are created in this process are appended to a list. This
         list of `img_ref`s is added as an attribute of the `world_refs` object.
-        
+
         Attributes set by this function:
-            self.all_img_refs (LIST) : List of all the `img_ref` objects found in 
+            self.all_img_refs (LIST) : List of all the `img_ref` objects found in
                 the world's JSON and DB files.
-        
+
         INPUTS:
         -------
         return_result (BOOL) : Indicates whether or not the function should return
             the `all_img_refs` list at the end of the process.
-        
+
         RETURNS:
         --------
-        all_img_refs (LIST) :  List of all the `img_ref` objects found in 
+        all_img_refs (LIST) :  List of all the `img_ref` objects found in
             the world's JSON and DB files.
-        
+
         '''
         # List of ALL images referenced in world
         self.all_img_refs = []
-        
+
         self.all_img_refs_by_id = {}
-        
+
         # Scanning all JSON files for references to images
         for this_json_file in self.json_files:
             this_json_file_content = self.json_files[this_json_file]
-            self.traverse_dict_and_find_all_refs(dict_content=this_json_file_content, 
-                                                 ref_file_path=this_json_file, 
+            self.traverse_dict_and_find_all_refs(dict_content=this_json_file_content,
+                                                 ref_file_path=this_json_file,
                                                  json_or_db='json')
-        
+
         # Scanning all DB files for references to images
         for this_db_file in self.db_files:
             for this_db_file_line,this_db_file_line_content in enumerate(self.db_files[this_db_file]):
-                self.traverse_dict_and_find_all_refs(dict_content=this_db_file_line_content, 
-                                                     ref_file_path=this_db_file, 
+                self.traverse_dict_and_find_all_refs(dict_content=this_db_file_line_content,
+                                                     ref_file_path=this_db_file,
                                                      json_or_db='db',
                                                      ref_file_line=this_db_file_line)
         if return_result:
             return self.all_img_refs
-        
-    
-    def traverse_dict_and_find_all_refs(self, dict_content=None, ref_file_path=None, 
+
+
+    def traverse_dict_and_find_all_refs(self, dict_content=None, ref_file_path=None,
                                         json_or_db=None, ref_file_line=None):
         '''
-        Function that traverses a JSON-like dictionary looking for references 
+        Function that traverses a JSON-like dictionary looking for references
         to images. For each reference that is found, an `img_ref` object is created
         and appended to the `self.all_img_refs` list.
-        
+
         INPUTS:
         -------
-        dict_content (DICT) : JSON-like content of the DB or JSON file. 
+        dict_content (DICT) : JSON-like content of the DB or JSON file.
         ref_file_path (STR) : Relative file path to the reference file that is
             being traversed. For example: 'worlds/porvenir/world.json' or
             'worlds/porvenir/data/actors.db'.
         json_or_db (STR) : String that describes whether the reference file being
-            traversed is a DB file or a JSON file. The acceptable/valid values 
+            traversed is a DB file or a JSON file. The acceptable/valid values
             for this variable are exclusively "json" or "db".
-        ref_file_line (INT or None): For '.db' reference files, there are multiple 
-            JSON-like dictionaries per row. The `ref_file_line` argument indicates 
-            which line in the ".db" file this particular `img_ref` can be found. 
-            For example, if the reference to the image is on the 5th line of the 
-            "journal.db" file, then `ref_file_line` will equal 4. In cases where 
-            the reference was found in a ".json" file, this attribute is instead 
+        ref_file_line (INT or None): For '.db' reference files, there are multiple
+            JSON-like dictionaries per row. The `ref_file_line` argument indicates
+            which line in the ".db" file this particular `img_ref` can be found.
+            For example, if the reference to the image is on the 5th line of the
+            "journal.db" file, then `ref_file_line` will equal 4. In cases where
+            the reference was found in a ".json" file, this attribute is instead
             set to None.
             NOTE: As with everything else in Python, this line number is zero-indexed.
-                
+
         RETURNS:
         --------
         None
-        
+
         '''
         # Regular Expression used to find image files
         #regex_img_exp = re.compile('.*\.webp|.*\.jpg|.*\.jpeg|.*\.png')
         #regex_img_exp = re.compile('.*\.webp.*|.*\.jpg.*|.*\.jpeg.*|.*\.png.*')
         regex_img_exp = re.compile('\.webp|\.jpg|\.jpeg|\.png')
-        
-        # Within each leaf of the dict tree, see if there is a 
-        # reference to an image. 
+
+        # Within each leaf of the dict tree, see if there is a
+        # reference to an image.
         for i,this_item in enumerate(dict_walker(dict_content)):
-            
+
             this_item_content = this_item[-1]
             if type(this_item_content) == str:
-                
+
                 # If an image extension is found, extract the full file path
                 if regex_img_exp.findall(this_item_content):
                     this_img_ref_content = this_item_content
-                    
+
                     # Check if leaf is an HTML block
                     if BeautifulSoup(this_img_ref_content, 'html.parser').find():
-                        
+
                         # If it is an HTML block, search for images
                         img_html_matches = BeautifulSoup(this_img_ref_content, 'html.parser').findAll("img")
                         unique_img_refs_in_html = {}
@@ -874,180 +874,180 @@ class world_refs:
                             if this_match['src'] not in unique_img_refs_in_html:
                                 unique_img_refs_in_html[this_match['src']] = 1
                             else:
-                                unique_img_refs_in_html[this_match['src']] += 1 
-                        
+                                unique_img_refs_in_html[this_match['src']] += 1
+
                         # For every image found, generate a reference_dict
                         for this_img_ref in unique_img_refs_in_html:
-                            this_ref_obj = img_ref(ref_file_type=json_or_db, 
-                                                   ref_file_path=ref_file_path, 
-                                                   ref_file_line=ref_file_line if json_or_db == 'db' else None, 
-                                                   full_json_address=this_item, 
+                            this_ref_obj = img_ref(ref_file_type=json_or_db,
+                                                   ref_file_path=ref_file_path,
+                                                   ref_file_line=ref_file_line if json_or_db == 'db' else None,
+                                                   full_json_address=this_item,
                                                    img_path_for_ref=this_img_ref,
                                                    world_refs_obj=self)
                             self.all_img_refs.append(this_ref_obj)
                             self.all_img_refs_by_id[this_ref_obj.ref_id] = this_ref_obj
-                            
+
                     # If the leaf is not an HTML chunk, it's an img reference,
                     # so we just need to add it to the list of references.
                     else:
-                        this_ref_obj = img_ref(ref_file_type=json_or_db, 
-                                               ref_file_path=ref_file_path, 
-                                               ref_file_line=ref_file_line if json_or_db == 'db' else None, 
-                                               full_json_address=this_item, 
+                        this_ref_obj = img_ref(ref_file_type=json_or_db,
+                                               ref_file_path=ref_file_path,
+                                               ref_file_line=ref_file_line if json_or_db == 'db' else None,
+                                               full_json_address=this_item,
                                                img_path_for_ref=this_img_ref_content,
                                                world_refs_obj=self)
                         self.all_img_refs.append(this_ref_obj)
                         self.all_img_refs_by_id[this_ref_obj.ref_id] = this_ref_obj
-                        
+
     def fix_incorrect_file_extensions(self):
         '''
-        Looks into the world's `img_ref`s and checks if their encoding matches 
-        the one in their respective file extensions. 
-        For example, consider that an `img_ref` points to a file on disk called 
-        "worlds/myworld/myimg.jpeg", but the actual encoding used for the image 
-        is "PNG". In that case, this function renames the file on disk to be 
-        "worlds/myworld/myimg.png", updates all the `img_ref` objects that point 
+        Looks into the world's `img_ref`s and checks if their encoding matches
+        the one in their respective file extensions.
+        For example, consider that an `img_ref` points to a file on disk called
+        "worlds/myworld/myimg.jpeg", but the actual encoding used for the image
+        is "PNG". In that case, this function renames the file on disk to be
+        "worlds/myworld/myimg.png", updates all the `img_ref` objects that point
         to that image and updates the `world_refs` object.
-        NOTE: This mehtod does not belong to the `img_ref` class on purpose! 
+        NOTE: This mehtod does not belong to the `img_ref` class on purpose!
         That's because one single image on disk can have multiple references in
         the world.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         refs_indexed_by_img = self.get_refs_indexed_by_img()
-        
+
         # Looping over every image found in references
         for img_counter, this_img_path in enumerate(refs_indexed_by_img):
             temp_ref = refs_indexed_by_img[this_img_path][0]
-            
-            # Ensuring that we only try to "fix" extensions for images that are 
+
+            # Ensuring that we only try to "fix" extensions for images that are
             # inside the world folder and that actually exist on disk
             if temp_ref.img_exists and temp_ref.ref_img_in_world_folder and not temp_ref.correct_extension:
                 old_content = temp_ref.get_img_ref_content()
                 old_img_path_for_ref = temp_ref.img_path_for_ref
-                
+
                 new_extension = temp_ref.img_encoding
                 new_img_path_for_ref = os.path.join(pathlib.Path(old_img_path_for_ref).parent,pathlib.Path(old_img_path_for_ref).stem) + '.' + new_extension
                 new_content = old_content.replace(old_img_path_for_ref,new_img_path_for_ref)
-                
+
                 os.rename(old_img_path_for_ref,new_img_path_for_ref)
-                
-                # After the file on disk was fixed, all the `img_ref`s that 
+
+                # After the file on disk was fixed, all the `img_ref`s that
                 # pointed to the old image need to be updated
                 for ref_counter, this_ref in enumerate(refs_indexed_by_img[this_img_path]):
                     this_ref.set_editable_attributes(new_img_path_for_ref)
                     this_ref.push_updated_content_to_world(new_content)
-            
-    
+
+
     def find_all_images_in_world_folder(self):
         '''
         Returns a list containing all of the images inside the World folder.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         all_images_in_world_folder (LIST) : List containing all of the images
             inside the World folder.
-        
+
         '''
         # Using rglob to find multiple patterns:
         types = ('*.jpg','*.jpeg','*.png','*.webp')
         all_images_in_world_folder = []
         for this_type in types:
             all_images_in_world_folder.extend(list(pathlib.Path(self.world_folder).rglob(this_type)))
-        
+
         # Fixing double backslash into forward slash
         for i,this_img in enumerate(all_images_in_world_folder):
             all_images_in_world_folder[i] = str(this_img).replace('\\','/')
-        
+
         return all_images_in_world_folder
-    
+
     def get_all_unused_images_in_world_folder(self):
         '''
         INPUTS:
         -------
-        Searches the world folder for all image files and compares it to the 
-        images being referenced in all of the `img_ref` objects. 
+        Searches the world folder for all image files and compares it to the
+        images being referenced in all of the `img_ref` objects.
         In the end, the function returns the list of unused images.
-        
+
         RETURNS:
         --------
         unused_images_in_world_folder (LIST) : list of all the unused images
             inside the world folder.
-        
+
         '''
         # Getting a list of all images on disk inside the World folder.
         all_images_in_world_folder = self.find_all_images_in_world_folder()
-        
+
         # Making a counter for each image inside the World folder.
         all_images_in_world_folder_dict = {}
         for this_img_in_folder in all_images_in_world_folder:
             all_images_in_world_folder_dict[this_img_in_folder] = 0
-        
-        # Looping over every `img_ref`. For each image found, we increment the 
+
+        # Looping over every `img_ref`. For each image found, we increment the
         # respective counter.
         for this_ref in self.all_img_refs:
             if this_ref.img_path_for_ref in all_images_in_world_folder_dict:
-                all_images_in_world_folder_dict[this_ref.img_path_for_ref] += 1 
-        
-        # Fishing out only images whose counters remain at zero. 
+                all_images_in_world_folder_dict[this_ref.img_path_for_ref] += 1
+
+        # Fishing out only images whose counters remain at zero.
         unused_images_in_world_folder = []
         for this_img_in_folder in all_images_in_world_folder_dict:
             if all_images_in_world_folder_dict[this_img_in_folder] == 0:
                 unused_images_in_world_folder.append(this_img_in_folder)
-        
+
         return unused_images_in_world_folder
-    
-    
+
+
     def add_unused_images_to_trash_queue(self):
         '''
         INPUTS:
         -------
         Scans the World folder for unused images and adds them all to the trash
-        queue. 
-        
+        queue.
+
         RETURNS:
         --------
         None
-        
+
         '''
         # Getting the list of unised images in World folder
         unused_images_in_world_folder = self.get_all_unused_images_in_world_folder()
-        
+
         # Adding all of them to the `trash_queue`
         for this_img in unused_images_in_world_folder:
             self.trash_queue.add(this_img.replace('\\','/'))
-    
+
     def get_broken_refs(self):
         '''
         INPUTS:
         -------
         Scans the World and finds references to images that do not exist on disk.
         In the end, the list of broken references is returned.
-        
+
         RETURNS:
         --------
         broken_refs (LIST) : List of `img_ref` objects containing references to
             images that do not exist on disk.
-        
+
         '''
         broken_ref_count = 0
         broken_refs = []
-        
-        # Looping over every `img_ref` object searching for references to files 
+
+        # Looping over every `img_ref` object searching for references to files
         # that don't exist in disk or that have already been added to the trash queue.
         for this_ref in self.all_img_refs:
-            if ((this_ref.img_path_on_disk == 'ERROR!!! IMG REFERENCE NOT ON DISK!!!') 
+            if ((this_ref.img_path_on_disk == 'ERROR!!! IMG REFERENCE NOT ON DISK!!!')
                 and (not this_ref.img_ref_external_web_link)) or (
                         this_ref.img_path_for_ref in self.trash_queue):
                 broken_ref_count += 1
@@ -1057,31 +1057,31 @@ class world_refs:
     def try_to_fix_one_broken_ref(self, img_ref_to_fix):
         '''
         Some older Foundry worlds pointed to the "modules" folder instead of the
-        "worlds" folder. This function takes one single `img_ref` object that points 
+        "worlds" folder. This function takes one single `img_ref` object that points
         to a file on disk that does not exist and checks if it points to an image
-        inside the "modules" folder instead. If it does, it tries to search for 
-        a file on disk with the same file path, but substituting "modules" with 
-        "worlds". If this new file path points to an image that actually exists, 
-        the `img_ref` is updated accordingly. 
-        
+        inside the "modules" folder instead. If it does, it tries to search for
+        a file on disk with the same file path, but substituting "modules" with
+        "worlds". If this new file path points to an image that actually exists,
+        the `img_ref` is updated accordingly.
+
         INPUTS:
         -------
         img_ref_to_fix (OBJECT) : An `img_ref` object whose file on disk will be
-            investigated for potential substitution from the "modules" folder 
-            to the "worlds" folder. 
-        
+            investigated for potential substitution from the "modules" folder
+            to the "worlds" folder.
+
         RETURNS:
         --------
         broken_ref_fixed (BOOL) : Indicates whether or not the `img_ref` object
             being evaluated was fixed.
-        
+
         '''
         # The default value below assumes that the broken ref will remain broken
         broken_ref_fixed = False
-        
+
         # Checks if the `img_ref` points to the "modules" folder
         if img_ref_to_fix.img_path_for_ref[:7] == 'modules':
-            
+
             # If it does, we try to swap the "modules" folder for the "world"
             # folder and see if this new file exists on disk. If so, the reference
             # is fixed!
@@ -1096,18 +1096,18 @@ class world_refs:
     def try_to_fix_all_broken_refs(self):
         '''
         Some older Foundry worlds pointed to the "modules" folder instead of the
-        "worlds" folder. This function scans all of the `img_ref`s in the World 
+        "worlds" folder. This function scans all of the `img_ref`s in the World
         and tried to fix them all. See the `try_to_fix_one_broken_ref` mehtod
         for more info.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         broken_refs = self.get_broken_refs()
         #broken_ref_imgs = self.get_refs_indexed_by_img(broken_refs)
@@ -1120,16 +1120,16 @@ class world_refs:
               ' `worlds` folder instead of `modules` folder.')
         #broken_refs = self.get_broken_refs()
         #print(f'Number of broken references after fix: {len(broken_refs)}')
-        
+
     def print_broken_ref_details(self):
         '''
-        Prints main details regarding broken refs: how many broken refs there 
+        Prints main details regarding broken refs: how many broken refs there
         are and how many actual images have broken refs.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
@@ -1138,23 +1138,23 @@ class world_refs:
         broken_ref_imgs = self.get_refs_indexed_by_img(broken_refs)
         print(f'Number of broken references: {len(broken_refs)}\n'
               f'Number of images with broken references: {len(list(broken_ref_imgs.keys()))}\n')
-        
+
     def get_refs_indexed_by_hash_by_img(self, input_ref_list=None):
         '''
-        Searches all the `img_ref`s in the world and builds an index of all the 
-        references. The dictionary created by this function indexes the refeences 
-        by hash and by image file path. 
-        
+        Searches all the `img_ref`s in the world and builds an index of all the
+        references. The dictionary created by this function indexes the refeences
+        by hash and by image file path.
+
         INPUTS:
         -------
-        input_ref_list (LIST or None) : List of references to be indexes. When 
+        input_ref_list (LIST or None) : List of references to be indexes. When
             this input is left blank (equal to "None"), the default behavior is
-            to just index all of the `img_ref`s in the `self.all_img_refs` 
+            to just index all of the `img_ref`s in the `self.all_img_refs`
             attribute.
-        
+
         RETURNS:
         --------
-        refs_indexed_by_hash_by_img (DICT) : Dictionary that indexes all of the 
+        refs_indexed_by_hash_by_img (DICT) : Dictionary that indexes all of the
             `img_ref` objects by their hashes and by the file paths of the images.
             Structure of output:
             refs_indexed_by_hash_by_img = {'hash_a':{'img_1':[ref_i,
@@ -1167,34 +1167,34 @@ class world_refs:
         '''
         # Preparing dictionary for indexing
         refs_indexed_by_hash_by_img = {}
-        
+
         # Checking which ref_list to use
         if input_ref_list==None:
             ref_list = self.all_img_refs
         else:
             ref_list = input_ref_list
-        
+
         # Looping over all of the `img_ref`s in `ref_list`
         for this_ref in ref_list:
             if this_ref.img_hash not in refs_indexed_by_hash_by_img:
                 refs_indexed_by_hash_by_img[this_ref.img_hash] = {}
-            
+
             if this_ref.img_path_for_ref not in refs_indexed_by_hash_by_img[this_ref.img_hash]:
                 refs_indexed_by_hash_by_img[this_ref.img_hash][this_ref.img_path_for_ref] = []
-                
+
             refs_indexed_by_hash_by_img[this_ref.img_hash][this_ref.img_path_for_ref].append(this_ref)
-        
+
         return refs_indexed_by_hash_by_img
 
     def get_duplicated_images(self):
         '''
         Scans all of the `img_ref` objects and finds which ones are duplicates
-        of each other. The results of this function are indexed by hash. 
-        
+        of each other. The results of this function are indexed by hash.
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         duplicated_images (DICT) : Dictionary that indexes the `img_ref` objects
@@ -1209,28 +1209,28 @@ class world_refs:
                                                     ref_vii]}}
         '''
         refs_indexed_by_hash_by_img = self.get_refs_indexed_by_hash_by_img()
-        
+
         duplicated_images_count_by_hash = 0
         duplicated_images = {}
         for this_hash in refs_indexed_by_hash_by_img:
             if (len(refs_indexed_by_hash_by_img[this_hash]) > 1) and (this_hash != None):
                 duplicated_images[this_hash] = refs_indexed_by_hash_by_img[this_hash]
                 duplicated_images_count_by_hash += 1
-    
+
         return duplicated_images
 
     def fix_one_set_of_duplicated_images(self, this_duplicated_img_dict=None):
         '''
-        Given a set of duplicated images, this function "fixes" all of the 
+        Given a set of duplicated images, this function "fixes" all of the
         references. Fixing them involves making all of the `img_ref` objects point
-        to one single image, the new `img_ref` info is pushed to the world and 
+        to one single image, the new `img_ref` info is pushed to the world and
         the unreferenced images are added to the trash queue.
-        
+
         INPUTS:
         -------
-        this_duplicated_img_dict (DICT) : a dictionary of `img_ref`s that point 
-        to different files on disk but which are all duplicated images. The 
-        dictionary is indexed by file path. 
+        this_duplicated_img_dict (DICT) : a dictionary of `img_ref`s that point
+        to different files on disk but which are all duplicated images. The
+        dictionary is indexed by file path.
             Structure of input:
             duplicated_images = {'img_1':[ref_i,
                                           ref_ii,
@@ -1239,86 +1239,86 @@ class world_refs:
                                           ref_v,
                                           ref_vi,
                                           ref_vii]}
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         main_img = list(this_duplicated_img_dict.keys())[0]
         imgs_to_be_replaced = list(this_duplicated_img_dict.keys())[1:]
-    
+
         for img_to_be_replaced in imgs_to_be_replaced:
             this_img_refs = this_duplicated_img_dict[img_to_be_replaced]
             for this_ref in this_img_refs:
                 updated_content = this_ref.get_img_ref_content().replace(this_ref.img_path_for_ref,main_img)
                 this_ref.set_editable_attributes(main_img)
                 this_ref.push_updated_content_to_world(updated_content)
-                
+
             self.trash_queue.add(img_to_be_replaced.replace('\\','/'))
 
     def fix_all_sets_of_duplicated_images(self):
         '''
         Scans all `img_ref`s in a world and fixes all of the sets of duplicated
-        images. 
-        
+        images.
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         duplicated_images = self.get_duplicated_images()
-        
+
         for this_hash in duplicated_images:
             this_duplicated_img_dict = duplicated_images[this_hash]
             self.fix_one_set_of_duplicated_images(this_duplicated_img_dict)
 
         duplicated_images = self.get_duplicated_images()
-    
+
     def update_one_ref_to_webp(self, img_ref_to_update=None):
         '''
-        Updates one single `img_ref` object such that it points to the ".webp" 
-        image on disk instead of whatever the original file type was. 
-        
+        Updates one single `img_ref` object such that it points to the ".webp"
+        image on disk instead of whatever the original file type was.
+
         INPUTS:
         -------
         img_ref_to_update (OBJECT) : instance of the `img_ref` class that will
             be updated by this function.
-        
+
         RETURNS:
         --------
         None
         '''
         old_img_path_for_ref = img_ref_to_update.img_path_for_ref
         old_img_ref_content  = img_ref_to_update.get_img_ref_content()
-        
+
         new_img_path_for_ref = img_ref_to_update.webp_img_path_for_ref
         new_img_ref_content  = old_img_ref_content.replace(old_img_path_for_ref,
                                                            new_img_path_for_ref)
-        
+
         img_ref_to_update.set_editable_attributes(new_img_path_for_ref)
         img_ref_to_update.push_updated_content_to_world(new_img_ref_content)
 
     def get_refs_indexed_by_img(self, input_ref_list=None):
         '''
-        Creates a dictionary that indexes all of the `img_ref` objects inside a 
-        Foundry World by file path. 
-        
+        Creates a dictionary that indexes all of the `img_ref` objects inside a
+        Foundry World by file path.
+
         INPUTS:
         -------
-        input_ref_list (LIST or None) : List of references to be indexes. When 
+        input_ref_list (LIST or None) : List of references to be indexes. When
             this input is left blank (equal to "None"), the default behavior is
-            to just index all of the `img_ref`s in the `self.all_img_refs` 
+            to just index all of the `img_ref`s in the `self.all_img_refs`
             attribute.
-        
+
         RETURNS:
         --------
         refs_indexed_by_img (DICT) : dictionary that indexes `img_ref` objects
-            by the image file paths. 
+            by the image file paths.
             Structure of output:
             refs_indexed_by_img = {'img_1':[ref_i,
                                             ref_ii,
@@ -1330,13 +1330,13 @@ class world_refs:
         '''
         # Preparing dictionary for output
         refs_indexed_by_img = {}
-        
+
         # Checking which ref_list to use
         if input_ref_list==None:
             ref_list = self.all_img_refs
         else:
             ref_list = input_ref_list
-        
+
         # Looping all the `img_ref`s in `ref_list`
         for this_ref in ref_list:
             if this_ref.img_path_for_ref not in refs_indexed_by_img:
@@ -1347,22 +1347,22 @@ class world_refs:
     def convert_all_images_to_webp_and_update_refs(self):
         '''
         Converts all of the images referenced in a Foundry World into a ".webp"
-        format, updates all of the `img_ref` objects and pushes all of the 
+        format, updates all of the `img_ref` objects and pushes all of the
         updated data back into the `world_refs` object.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         refs_indexed_by_img = self.get_refs_indexed_by_img()
-        
+
         printed_percentages = {}
-        
+
         for img_counter, this_img_path in enumerate(refs_indexed_by_img):
             temp_ref = refs_indexed_by_img[this_img_path][0]
             temp_path_for_deletion = this_img_path
@@ -1379,27 +1379,27 @@ class world_refs:
                         self.update_one_ref_to_webp(this_ref)
                 self.trash_queue.add(temp_path_for_deletion.replace('\\','/'))
         print('Scanned 100% of all images.')
-        
+
     def export_all_json_and_db_files(self):
         '''
-        Creates a backup of the ".json" & ".db" files on disk and exports the 
+        Creates a backup of the ".json" & ".db" files on disk and exports the
         data inside the `world_refs` object into new ".json" & ".db" files onto
         the disk.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         # Scanning all JSON files for references to images
         for this_json_file in self.json_files:
             # Backing up current JSON file
             shutil.copyfile(this_json_file, this_json_file+'bak')
-            
+
             this_json_file_content = self.json_files[this_json_file]
             # Writing JSON files to disk
             with open(this_json_file,'w',encoding="utf-8") as fout:
@@ -1409,78 +1409,78 @@ class world_refs:
         for this_db_file in self.db_files:
             # Backing up current DB file
             shutil.copyfile(this_db_file, this_db_file+'bak')
-            
+
             # Writing DB files to disk, line by line
             with open(this_db_file,'w',encoding="utf-8") as fout:
                 for this_db_file_line,this_db_file_line_content in enumerate(self.db_files[this_db_file]):
                     new_line = json.dumps(this_db_file_line_content,separators=(',', ':'),ensure_ascii=False) + '\n'
                     fout.writelines([new_line])
-    
+
     def find_refs_by_img_path(self, img_path_to_search=None):
         '''
-        Gets a list of all the `img_ref` objects that point to a specific file 
+        Gets a list of all the `img_ref` objects that point to a specific file
         on disk.
-        
+
         INPUTS:
         -------
-        img_path_to_search (STR) : string that describes the file path of the 
+        img_path_to_search (STR) : string that describes the file path of the
             image being searched.
-        
+
         RETURNS:
         --------
-        found_refs (LIST) : list of `img_ref` objects that all point to the same 
+        found_refs (LIST) : list of `img_ref` objects that all point to the same
             image file on disk.
-        
+
         '''
         found_refs = []
         for this_ref in self.all_img_refs:
             if this_ref.img_path_for_ref == img_path_to_search:
                 found_refs.append(this_ref)
         return found_refs
-    
+
     def move_all_imgs_in_trash_queue_to_trash(self):
         '''
         Function used to actually move the files from the `trash_queue` into the
         "_trash" folder inside the world.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         for this_file in self.trash_queue:
-            
-            # Making sure that the file exists and that it is actually inside 
+
+            # Making sure that the file exists and that it is actually inside
             # the world folder. This is to prevent accidentally moving images
             # from the Foundry Core folder
-            if (os.path.isfile(this_file) and 
+            if (os.path.isfile(this_file) and
                 re.match('.*' + self.world_folder + '.*', this_file)):
                 temp = re.split('\\\\|/',this_file)
                 temp.insert(2,'_trash')
                 trash_name = os.path.join(*temp).replace('\\','/')
                 os.makedirs(os.path.dirname(trash_name), exist_ok=True)
                 os.rename(this_file,trash_name)
-    
+
     def empty_trash(self,delete_unreferenced_images=False):
         '''
         Actually deletes the content inside the "_trash" folder inside the world.
         Careful when using this function!!! This function has no "undo"!!!!!
-        
+
         INPUTS:
         -------
-        delete_unreferenced_images_bool (BOOL) : indicates whether or not the 
-            files in the "_trash" folder should actually be deleted. When this 
-            input is set to "False", the function will simply terminate without 
+        delete_unreferenced_images_bool (BOOL) : indicates whether or not the
+            files in the "_trash" folder should actually be deleted. When this
+            input is set to "False", the function will simply terminate without
             deleting anything.
-        
+
         RETURNS:
         --------
         None
-        
+
         '''
         if delete_unreferenced_images:
             shutil.rmtree(self.trash_folder)
@@ -1489,22 +1489,22 @@ class world_refs:
         '''
         Restores the ".jsonbak" and "dbbak" files to ".json" and ".db" respectively.
         Note: this process overwrites whatever was in their places.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
         '''
         list_of_dbbak_files   = [str(this_path).replace('\\','/') for this_path in pathlib.Path(self.world_folder).rglob('*.dbbak')]
         list_of_jsonbak_files = [str(this_path).replace('\\','/') for this_path in pathlib.Path(self.world_folder).rglob('*.jsonbak')]
-        
+
         for this_dbbak_file in list_of_dbbak_files:
             this_dborig_file = this_dbbak_file[:-3]
             shutil.move(this_dbbak_file,this_dborig_file,)
-            
+
         for this_jsonbak_file in list_of_jsonbak_files:
             this_jsonorig_file = this_jsonbak_file[:-3]
             shutil.move(this_jsonbak_file,this_jsonorig_file)
@@ -1512,65 +1512,65 @@ class world_refs:
     def restore_trash_folder(self):
         '''
         Restores files that got sent to the "_trash" folder.
-        
+
         INPUTS:
         -------
         None
-        
+
         RETURNS:
         --------
         None
         '''
-        
+
         trash_files_and_folders = os.listdir(self.trash_folder)
-        
+
         for this_item in trash_files_and_folders:
             pass
             shutil.move(os.path.join(self.trash_folder,this_item),
                         os.path.join(self.world_folder,this_item))
-    
+
 
 def input_checker(user_data_folder=None, world_folder=None,
-                  core_data_folder=None,ffmpeg_location=None, 
+                  core_data_folder=None,ffmpeg_location=None,
                   delete_unreferenced_images=False):
     '''
     Checks all of the inputs to make sure they are valid. For the folder inputs,
-    it checks that the folders exist. For the FFMPEG input, it checks if the 
-    ".exe" executable file exists on disk. For the flag that determines whether 
+    it checks that the folders exist. For the FFMPEG input, it checks if the
+    ".exe" executable file exists on disk. For the flag that determines whether
     or not files will actually be deleted, it checks if the input is "y" or "n".
-    
+
     !!!Note: This is also where the working directory is set!
-    
+
     !!!TODO: I need to update this function when I make the call to FFMPEG
     work across platforms (Linux & Mac).
-    
+
     INPUTS:
     -------
-    user_data_folder (STR) : String that describes the absolute path for 
-        the user data folder on disk. On Windows installations, this attribute 
+    user_data_folder (STR) : String that describes the absolute path for
+        the user data folder on disk. On Windows installations, this attribute
         should typically look something like this: "C:/Users/jegasus/AppData/Local/FoundryVTT/Data"
-    world_folder (STR) : String that describes the relative path to the 
-        world folder to be scanned by the world reference tool. This path needs 
+    world_folder (STR) : String that describes the relative path to the
+        world folder to be scanned by the world reference tool. This path needs
         to be relative to the user data folder (i.e., the combination of the
-        `user_data_folder` attribute and the `world_folder` represent the 
-        absolute path of the World folder to be scanned. This attribute should 
+        `user_data_folder` attribute and the `world_folder` represent the
+        absolute path of the World folder to be scanned. This attribute should
         typically look like this: "worlds/porvenir", or "worlds/kobold-cauldron".
-    core_data_folder (STR) : String that describes the absolute path to the 
-        Foundry Core Data folder. This attribute should typically look like 
+    core_data_folder (STR) : String that describes the absolute path to the
+        Foundry Core Data folder. This attribute should typically look like
         this: "C:/Program Files/FoundryVTT/resources/app/public"
-    ffmpeg_location (STR) : String that describes the absolute path to 
+    ffmpeg_location (STR) : String that describes the absolute path to
         the ffmpeg executable. This attribute should typically look like this:
         "C:/Program Files (x86)/Audacity/libraries/ffmpeg.exe".
-    delete_unreferenced_images (STR) : string that indicates whether or not the 
+    delete_unreferenced_images (STR) : string that indicates whether or not the
         files that got placed in the "_trash" folder should actually be deleted
         at the end of the process. This attribute expects either "y" or "n".
-        
-    
+
+
     RETURNS:
     --------
-    checked_inputs (DICT) : A dictionary containing the verified and modified 
-        inputs. 
-    
+    checked_inputs (DICT) : A dictionary containing the verified and modified
+        inputs.
+
     EXAMPLE:
     --------
     # Input:
@@ -1579,7 +1579,7 @@ def input_checker(user_data_folder=None, world_folder=None,
                                    core_data_folder = "C:/Program Files/FoundryVTT/resources/app/public",
                                    ffmpeg_location  = "C:/Program Files (x86)\Audacity/libraries/ffmpeg.exe",
                                    delete_unreferenced_images="n")
-    
+
     user_data_folder_checked = checked_inputs["user_data_folder"]
     world_folder_checked = checked_inputs["world_folder"]
     core_data_folder_checked = checked_inputs["core_data_folder"]
@@ -1597,28 +1597,28 @@ def input_checker(user_data_folder=None, world_folder=None,
 
     if type(ffmpeg_location) != str:
         raise AssertionError('The type of value supplied for the `ffmpeg_location` variable is not valid. Please provide a string value.')
-        
+
     if type(delete_unreferenced_images) != str:
         raise AssertionError('The type of value supplied for the `delete_unreferenced_images` variable is not valid. Please provide a string value.')
-    
-    
+
+
     user_data_folder = os.path.normpath(user_data_folder).replace("\\","/")
     if not os.path.isdir(user_data_folder):
         raise NotADirectoryError(f'The `user_data_folder` supplied does not exist: {user_data_folder}')
-    
+
     world_folder = os.path.normpath(world_folder).replace("\\","/")
     if not os.path.isdir(os.path.join(user_data_folder,os.path.normpath(world_folder))):
         raise NotADirectoryError(f'The `world_folder` supplied does not exist: {world_folder}')
-        
+
     core_data_folder = os.path.normpath(core_data_folder).replace("\\","/")
     if not os.path.isdir(core_data_folder):
         raise NotADirectoryError(f'The `core_data_folder` supplied does not exist: {core_data_folder}')
-    
+
     # !!! FIX HERE FOR CROSS-PLATFORM CHECKING
     ffmpeg_location = os.path.normpath(ffmpeg_location).replace("\\","/")
     if not os.path.isfile(ffmpeg_location):
         raise NotADirectoryError(f'The `ffmpeg_location` supplied does not exist: {ffmpeg_location}')
-    
+
     if delete_unreferenced_images.lower() == 'y':
         delete_unreferenced_images_bool = True
     elif delete_unreferenced_images.lower() == 'n':
@@ -1626,15 +1626,15 @@ def input_checker(user_data_folder=None, world_folder=None,
     else:
         raise ValueError(f'The value supplied to the `delete_unreferenced_images` flag \
                          is not valid. Please type in either "y" or "n".')
-        
-    checked_inputs = {'user_data_folder':user_data_folder, 
+
+    checked_inputs = {'user_data_folder':user_data_folder,
                       'world_folder':world_folder,
                       'core_data_folder':core_data_folder,
-                      'ffmpeg_location':ffmpeg_location, 
+                      'ffmpeg_location':ffmpeg_location,
                       'delete_unreferenced_images':delete_unreferenced_images_bool}
-    
+
     os.chdir(user_data_folder)
-    
+
     return checked_inputs
 
 
@@ -1642,50 +1642,50 @@ def input_checker(user_data_folder=None, world_folder=None,
 def one_liner_compress_world(user_data_folder=None, world_folder=None,core_data_folder=None,
                              ffmpeg_location=None, delete_unreferenced_images=False):
     '''
-    Main function to compress the Foudry World. 
-    
+    Main function to compress the Foudry World.
+
     INPUTS:
     -------
-    user_data_folder (STR) : String that describes the absolute path for 
-        the user data folder on disk. On Windows installations, this attribute 
+    user_data_folder (STR) : String that describes the absolute path for
+        the user data folder on disk. On Windows installations, this attribute
         should typically look something like this: "C:/Users/jegasus/AppData/Local/FoundryVTT/Data"
-    world_folder (STR) : String that describes the relative path to the 
-        world folder to be scanned by the world reference tool. This path needs 
+    world_folder (STR) : String that describes the relative path to the
+        world folder to be scanned by the world reference tool. This path needs
         to be relative to the user data folder (i.e., the combination of the
-        `user_data_folder` attribute and the `world_folder` represent the 
-        absolute path of the World folder to be scanned. This attribute should 
+        `user_data_folder` attribute and the `world_folder` represent the
+        absolute path of the World folder to be scanned. This attribute should
         typically look like this: "worlds/porvenir", or "worlds/kobold-cauldron".
-    core_data_folder (STR) : String that describes the absolute path to the 
-        Foundry Core Data folder. This attribute should typically look like 
+    core_data_folder (STR) : String that describes the absolute path to the
+        Foundry Core Data folder. This attribute should typically look like
         this: "C:/Program Files/FoundryVTT/resources/app/public"
-    ffmpeg_location (STR) : String that describes the absolute path to 
+    ffmpeg_location (STR) : String that describes the absolute path to
         the ffmpeg executable. This attribute should typically look like this:
         "C:/Program Files (x86)/Audacity/libraries/ffmpeg.exe".
-    delete_unreferenced_images (STR) : string that indicates whether or not the 
+    delete_unreferenced_images (STR) : string that indicates whether or not the
         files that got placed in the "_trash" folder should actually be deleted
         at the end of the process. This attribute expects either "y" or "n".
-    
+
     RETURNS:
     --------
     None
-    
+
     EXAMPLE:
     --------
     # Input:
     None
-    
+
     # Output:
     # None
     '''
     checked_inputs = input_checker(user_data_folder,world_folder,core_data_folder,
                                    ffmpeg_location,delete_unreferenced_images)
-    
+
     user_data_folder_checked = checked_inputs['user_data_folder']
     world_folder_checked = checked_inputs['world_folder']
     core_data_folder_checked = checked_inputs['core_data_folder']
     ffmpeg_location_checked = checked_inputs['ffmpeg_location']
     delete_unreferenced_images_checked = checked_inputs['delete_unreferenced_images']
-    
+
     my_world_refs = world_refs(user_data_folder_checked,world_folder_checked,
                                core_data_folder_checked,ffmpeg_location_checked)
 
@@ -1699,7 +1699,7 @@ def one_liner_compress_world(user_data_folder=None, world_folder=None,core_data_
     my_world_refs.add_unused_images_to_trash_queue()
     my_world_refs.move_all_imgs_in_trash_queue_to_trash()
     my_world_refs.empty_trash(delete_unreferenced_images_checked)
-    
+
     return my_world_refs
 
 


### PR DESCRIPTION
I put this up more as a template for an environment/workflow that I find very useful for python development. 

### Relevant changes
* Use [poetry ](https://python-poetry.org/docs/)for packaging and dependency management
* Add minimal gitignore
* Add single test for dict_walker based on docs
* Added `cli` entrypoint for users of installed package

### Less important changes & notes
* Removed trailing whitespace
* Added dev dependency on poethepoet for task running
* Added black for code formatting (Intentionally didn't run this on existing files to avoid cluttering current PR)

If you like these changes or have any questions about intent I'd be happy to talk about it.